### PR TITLE
fix the build against latest LD master

### DIFF
--- a/src/PrometheusStatsPublisher.cpp
+++ b/src/PrometheusStatsPublisher.cpp
@@ -81,6 +81,12 @@ class PrometheusEnumerationCallback : public Stats::EnumerationCallbacks {
   void stat(const std::string& name, Priority, int64_t val) override {
     // Not needed as it's included in the per-flow-group per message one.
   }
+  // Per-monitoring-tier stats
+  void stat(const std::string& name,
+	    MonitoringTier monitoring_tier,
+	    int64_t val) override {
+    updateCounter(name, {{"monitoring_tier", toString(monitoring_tier)}}, val);
+  }
   // Per-request-type stats.
   void stat(const std::string& name, RequestType type, int64_t val) override {
     updateCounter(name, {{"request_type", requestTypeNames[type]}}, val);


### PR DESCRIPTION
Added PrometheusEnumerationCallback::stats(...MonitoringTier...) overload.
This fixes the build against latest LD master.